### PR TITLE
react-dnd-html5-backend: do not stop propagation when dragging native item

### DIFF
--- a/packages/react-dnd-html5-backend/src/HTML5Backend.js
+++ b/packages/react-dnd-html5-backend/src/HTML5Backend.js
@@ -483,8 +483,14 @@ export default class HTML5Backend {
     } else if (this.isDraggingNativeItem()) {
       // Don't show a nice cursor but still prevent default
       // "drop and blow away the whole document" action.
-      e.preventDefault();
-      e.dataTransfer.dropEffect = 'none';
+      /**
+       * Modified by Cheng
+       * we use other module to handle picture file drag to upload,
+       * so we can not prevent drag native item propagation
+       */
+      // e.preventDefault();
+      // e.dataTransfer.dropEffect = 'none';
+      e.dataTransfer.dropEffect = 'move';
     } else if (this.checkIfCurrentDragSourceRectChanged()) {
       // Prevent animating to incorrect position.
       // Drop effect must be other than 'none' to prevent animation.


### PR DESCRIPTION
Since we use other module to handle the image upload when user drag picture file from outside to browser window, we should not stop propagation for native files in react-dnd-html5-backend module